### PR TITLE
fix(Influx): fix ticks time units

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,8 @@ func initConfig() {
 		}
 	}
 
+	viper.SetDefault("timeunit", "us")
+
 	// Load user defined config
 	cfgFile := viper.GetString("config")
 	if cfgFile != "" {


### PR DESCRIPTION
InfluxQL ticks are in nanoseconds (https://docs.influxdata.com/influxdb/v1.8/query_language/explore-data/#time-syntax) and convert them into the correct Warp10 platform one