### PR TITLE
Lat and long values in series 

### DIFF
--- a/proto/prom/utils.go
+++ b/proto/prom/utils.go
@@ -54,9 +54,19 @@ func warpMetricstoPrometheus(gts core.GeoTimeSeries) prometheusResultResponse {
 	for _, value := range gts.Values {
 		ts := value[0].(float64) // Casting as gts is an interface
 		ts /= 1000000.0          // Moving from us to ms
-		v = fmt.Sprintf("%v", value[1])
 
-		p.Values = append(p.Values, []interface{}{ts, v})
+		// handling value case, when lat,long are specified string can occure from PromQL values
+		switch val := value[len(value)-1].(type) {
+		case float64:
+			v = fmt.Sprintf("%f", val)
+			p.Values = append(p.Values, []interface{}{ts, v})
+		case string:
+			floatVal, err := strconv.ParseFloat(val, 64)
+			if err == nil {
+				v = fmt.Sprintf("%f", floatVal)
+				p.Values = append(p.Values, []interface{}{ts, v})
+			}
+		}
 	}
 	return p
 }
@@ -69,9 +79,19 @@ func warpScalarToPrometheus(gts core.GeoTimeSeries) prometheusResultResponse {
 	for _, value := range gts.Values {
 		ts := value[0].(float64) // Casting as gts is an interface
 		ts /= 1000000.0          // Moving from us to ms
-		v = fmt.Sprintf("%f", value[1].(float64))
 
-		p.Values = append(p.Values, []interface{}{ts, v})
+		// handling value case, when lat,long are specified string can occure from PromQL values
+		switch val := value[len(value)-1].(type) {
+		case float64:
+			v = fmt.Sprintf("%f", val)
+			p.Values = append(p.Values, []interface{}{ts, v})
+		case string:
+			floatVal, err := strconv.ParseFloat(val, 64)
+			if err == nil {
+				v = fmt.Sprintf("%f", floatVal)
+				p.Values = append(p.Values, []interface{}{ts, v})
+			}
+		}
 	}
 	return p
 }


### PR DESCRIPTION
Having  series with lat and long values set implied the use of "Longitude" as PromQL query value result. 
Fix it to retrieve real time series result, and fix some case where with Lat and Long set, the float value returned by the Warp10 query is considered as a String