### PR TITLE
fix: label data don't have to be altered to fit prometheus specifications

### DIFF
--- a/proto/prom/utils.go
+++ b/proto/prom/utils.go
@@ -53,7 +53,6 @@ func warpMetricstoPrometheus(gts core.GeoTimeSeries) prometheusResultResponse {
 			outputToReplace := viper.GetStringMapString("prometheus.query.labels.replace.map")
 			for replaceKey, replaceValue := range outputToReplace {
 				labelKey = strings.Replace(labelKey, replaceKey, replaceValue, -1)
-				labelValue = strings.Replace(labelValue, replaceKey, replaceValue, -1)
 			}
 			gtsLabels[labelKey] = labelValue
 		}

--- a/proto/prom_remote/prom_remote.go
+++ b/proto/prom_remote/prom_remote.go
@@ -181,7 +181,6 @@ func gtsToPromTS(gts core.GeoTimeSeries) *prompb.TimeSeries {
 			outputToReplace := viper.GetStringMapString("prometheus.remote_read.meta.replace.map")
 			for replaceKey, replaceValue := range outputToReplace {
 				labelKey = strings.Replace(labelKey, replaceKey, replaceValue, -1)
-				labelValue = strings.Replace(labelValue, replaceKey, replaceValue, -1)
 			}
 		}
 		ts.Labels = append(ts.Labels, &prompb.Label{


### PR DESCRIPTION
According to https://prometheus.io/docs/concepts/data_model/

> Label values may contain any Unicode characters.